### PR TITLE
completed testing, logic, and bugs found in org membership apis

### DIFF
--- a/requisite-api/jest.config.js
+++ b/requisite-api/jest.config.js
@@ -12,5 +12,13 @@ module.exports = {
     //         statements: 90
     //     }
     // },
+    coverageThreshold: {
+        global: {
+            branches: 65,
+            functions: 60,
+            lines: 75,
+            statements: 75
+        }
+    },
     testPathIgnorePatterns: ['dist']
 };

--- a/requisite-api/src/common/ResourceEntityHandler.ts
+++ b/requisite-api/src/common/ResourceEntityHandler.ts
@@ -1,0 +1,45 @@
+import { Response, NextFunction } from 'express';
+import { getLogger } from '../util/Logger';
+import ResourceRequest from './ResourceRequest';
+import { assertExists } from '@requisite/utils/lib/validation/AssertionUtils';
+import Entity from '@requisite/model/lib/Entity';
+import { NotFoundError } from '../util/ApiErrors';
+
+const logger = getLogger('common/ResourceEntityHandler');
+
+const getEntityHandler = (
+    entityName: string,
+    entityIdParam: string,
+    contextIdParams: string[],
+    lookupEntity: (
+        entityId: number,
+        contextIds: Record<string, number>
+    ) => Promise<Entity>
+) => {
+    return function(req: ResourceRequest, res: Response, next: NextFunction): void {
+        (async function() {
+            try {
+                assertExists(req.params[entityIdParam], `req.params.${entityIdParam}`);
+                const entityId = parseInt(req.params[entityIdParam]);
+
+                const contextIds: Record<string, number> = {};
+                contextIdParams.forEach((contextIdParam) => {
+                    assertExists(req.params[contextIdParam], `req.params.${contextIdParam}`);
+                    contextIds[contextIdParam] = parseInt(req.params[contextIdParam]);
+                });
+                const entity = await lookupEntity(entityId, contextIds);
+                if (entity) {
+                    logger.debug(`Found ${entityName} [${entityId}]: `, entity);
+                    req.entity = entity;
+                    next();
+                } else {
+                    next(new NotFoundError(`${entityName} [${entityId}] not found`));
+                }
+            } catch(error) {
+                next(error);
+            }
+        })();
+    };
+};
+
+export { getEntityHandler };

--- a/requisite-api/src/common/ResourceRequest.ts
+++ b/requisite-api/src/common/ResourceRequest.ts
@@ -2,9 +2,11 @@ import { Request  } from 'express';
 import SecurityContext from '@requisite/model/lib/user/SecurityContext';
 import Organization from '@requisite/model/lib/org/Organization';
 import Product from '@requisite/model/lib/product/Product';
+import Entity from '@requisite/model/lib/Entity';
 
 export default interface ResourceRequest extends Request {
-    securityContext: SecurityContext;
+    securityContext?: SecurityContext;
     organization?: Organization;
-    product: Product;
+    product?: Product;
+    entity?: Entity;
 }

--- a/requisite-api/src/resources/organization-memberships/OrgMembershipsDeleteResource.ts
+++ b/requisite-api/src/resources/organization-memberships/OrgMembershipsDeleteResource.ts
@@ -11,8 +11,7 @@ export default (req: ResourceRequest, res: Response, next: NextFunction): void =
     (async function() {
         try {
             logger.debug('Executing org memberships delete resource');
-            assertExists(req.securityContext, 'req.securityContext');
-            assertExists(req.organization, 'req.organization');
+            assertExists(req.entity, 'req.entity');
             const id = parseInt(req.params.membershipId);
             const organizationsService = ServiceProvider.getOrganizationsService();
             const membership = await organizationsService.getMembership(id);

--- a/requisite-api/src/services/OrganizationsServiceSqlzImpl.ts
+++ b/requisite-api/src/services/OrganizationsServiceSqlzImpl.ts
@@ -69,12 +69,11 @@ export default class OrganizationsServiceSqlzImpl implements OrganizationsServic
         );
     }
     async getMembership(id: number): Promise<Membership<Organization>> {
-        return OrgMembershipsDataModel.toOrgMembership(
-            await runWithSequelize(async (sqlz) => {
-                OrgMembershipsDataModel.initialize(sqlz);
-                return OrgMembershipsDataModel.findByPk(id);
-            })
-        );
+        const membership = await runWithSequelize(async (sqlz) => {
+            OrgMembershipsDataModel.initialize(sqlz);
+            return OrgMembershipsDataModel.findByPk(id);
+        });
+        return membership ? OrgMembershipsDataModel.toOrgMembership(membership) : null;
     }
     async addMembership(
         membership: Membership<Organization>

--- a/requisite-api/src/services/sqlz/data-models/FeaturesDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/FeaturesDataModel.ts
@@ -75,7 +75,7 @@ export default class FeaturesDataModel extends Model implements Feature {
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toFeature(model: FeaturesDataModel): Feature {
-        const feature = model.toJSON ? model.toJSON() as FeaturesDataModel : model;
+        const feature = model.toJSON ? model.toJSON() : model;
         delete feature.productId;
         delete feature.data;
         delete feature.createdAt;

--- a/requisite-api/src/services/sqlz/data-models/OrgMembershipsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/OrgMembershipsDataModel.ts
@@ -77,9 +77,9 @@ export default class OrgMembershipsDataModel
     }
 
     public static toOrgMembership(
-        membership: OrgMembershipsDataModel
+        model: OrgMembershipsDataModel
     ): Membership<Organization> {
-        const orgMembership = membership.toJSON() as OrgMembershipsDataModel;
+        const orgMembership = model.toJSON ? model.toJSON() : model;
         (orgMembership as Membership<Organization>).user
             = UsersDataModel.toUser(orgMembership.user);
         (orgMembership as Membership<Organization>).entity

--- a/requisite-api/src/services/sqlz/data-models/OrganizationsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/OrganizationsDataModel.ts
@@ -41,7 +41,7 @@ export default class OrganizationsDataModel extends Model implements Organizatio
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toOrganization(model: OrganizationsDataModel): Organization {
-        const org = model.toJSON ? model.toJSON() as OrganizationsDataModel : model;
+        const org = model.toJSON ? model.toJSON() : model;
         delete org.data;
         delete org.createdAt;
         delete org.updatedAt;

--- a/requisite-api/src/services/sqlz/data-models/ProductConstituentsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/ProductConstituentsDataModel.ts
@@ -80,9 +80,7 @@ export default class ProductConstituentsDataModel extends Model implements Const
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toConstituent(model: ProductConstituentsDataModel): Constituent {
-        const constituent = model.toJSON
-            ? model.toJSON() as ProductConstituentsDataModel
-            : model;
+        const constituent = model.toJSON ? model.toJSON() : model;
         delete constituent.productId;
         delete constituent.data;
         delete constituent.createdAt;

--- a/requisite-api/src/services/sqlz/data-models/ProductMembershipsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/ProductMembershipsDataModel.ts
@@ -79,9 +79,9 @@ export default class ProductMembershipsDataModel
     }
 
     public static toProductMembership(
-        dataModel: ProductMembershipsDataModel
+        model: ProductMembershipsDataModel
     ): Membership<Product> {
-        const prodMembership = dataModel.toJSON() as ProductMembershipsDataModel;
+        const prodMembership = model.toJSON ? model.toJSON() : model;
         (prodMembership as Membership<Product>).user
             = UsersDataModel.toUser(prodMembership.user);
         (prodMembership as Membership<Product>).entity

--- a/requisite-api/src/services/sqlz/data-models/ProductsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/ProductsDataModel.ts
@@ -80,7 +80,7 @@ export default class ProductsDataModel extends Model implements Product {
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toProduct(model: ProductsDataModel): Product {
-        const product = model.toJSON ? model.toJSON() as ProductsDataModel : model;
+        const product = model.toJSON ? model.toJSON() : model;
         delete product.organizationId;
         delete product.data;
         delete product.createdAt;

--- a/requisite-api/src/services/sqlz/data-models/StoriesDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/StoriesDataModel.ts
@@ -90,7 +90,7 @@ export default class StoriesDataModel extends Model implements Story {
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toStory(model: StoriesDataModel): Story {
-        const story = model.toJSON ? model.toJSON() as StoriesDataModel : model;
+        const story = model.toJSON ? model.toJSON() : model;
         delete story.featureId;
         delete story.constituentId;
         delete story.data;

--- a/requisite-api/src/services/sqlz/data-models/StoryRevisionsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/StoryRevisionsDataModel.ts
@@ -110,7 +110,7 @@ export default class StoryRevisionsDataModel extends Model implements StoryRevis
      * Convert to a JSON object and remove some DB specific fields
      */
     public static toStoryRevision(model: StoryRevisionsDataModel): StoryRevision {
-        const revision = model.toJSON ? model.toJSON() as StoryRevisionsDataModel : model;
+        const revision = model.toJSON ? model.toJSON() : model;
         delete revision.storyId;
         delete revision.data;
         delete revision.createdAt;

--- a/requisite-api/src/services/sqlz/data-models/SystemAdminsDataModel.ts
+++ b/requisite-api/src/services/sqlz/data-models/SystemAdminsDataModel.ts
@@ -65,7 +65,7 @@ export default class SystemAdminsDataModel extends Model implements SystemAdmin 
     }
 
     public static toSystemAdmin(model: SystemAdminsDataModel): SystemAdmin {
-        const sysAdmin = model.toJSON ? model.toJSON() as SystemAdminsDataModel : model;
+        const sysAdmin = model.toJSON ? model.toJSON() : model;
         const { id, userName, emailAddress, name } = sysAdmin.user || {};
         sysAdmin.user = { id, userName, emailAddress, name } as User;
         delete sysAdmin.userId;

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.delete.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.delete.test.ts
@@ -1,0 +1,88 @@
+import '../supertest.mock.sqlz';
+import '../supertest.mock.jsonwebtoken';
+import request from 'supertest';
+import { getApp } from '../../src/app';
+import { configure } from '../../src/util/Logger';
+import { ValidationResult } from '@requisite/utils/lib/validation/ValidationUtils';
+import OrgMembershipsDataModel from '../../src/services/sqlz/data-models/OrgMembershipsDataModel';
+import { getSequelize } from '../../src/services/sqlz/SqlzUtils';
+import Organization from '@requisite/model/lib/org/Organization';
+import Membership from '@requisite/model/lib/user/Membership';
+
+configure('ERROR');
+
+async function getMockedOrgMemberships(
+    orgId: number
+): Promise<Membership<Organization>[]> {
+    OrgMembershipsDataModel.initialize(await getSequelize());
+    return (await OrgMembershipsDataModel.findAll({
+        where: { orgId }
+    })).map(
+        m => OrgMembershipsDataModel.toOrgMembership(m)
+    );
+}
+
+describe('DELETE /orgs/<orgId>/memberships/<orgMembershipId>', () => {
+    test('returns a 401 Unauthorized response when no auth header is present', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/0')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when an invalid auth header is present', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer invalid')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for an unknown user', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|unknown')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for a revoked user', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|revoked')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 403 Not Authorized when a valid auth header is present but not for an org owner', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|org0MemberProduct0Owner')
+            .expect(403, 'Not Authorized');
+    });
+    test('returns a 400 Bad Request response when an invalid index', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/abc')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 404 Not Found response when an unknown index', async () => {
+        return request(getApp())
+            .delete('/orgs/0/memberships/123')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(404, 'Not Found');
+    });
+    test('returns a 200 with data when a valid auth header is present for a sys admin', async () => {
+        const orgMemberships = await getMockedOrgMemberships(1);
+        const orgIdToDelete = orgMemberships[0].id;
+        return request(getApp())
+            .delete(`/orgs/1/memberships/${orgIdToDelete}`)
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(200);
+    });
+    test('returns a 200 with data when a valid auth header is present for an org owner', async () => {
+        const orgMemberships = await getMockedOrgMemberships(0);
+        const orgIdToDelete = orgMemberships[0].id;
+        return request(getApp())
+            .delete(`/orgs/0/memberships/${orgIdToDelete}`)
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .expect(200);
+    });
+});

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.get.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.get.test.ts
@@ -1,0 +1,114 @@
+import '../supertest.mock.sqlz';
+import '../supertest.mock.jsonwebtoken';
+import request from 'supertest';
+import { getApp } from '../../src/app';
+import { configure } from '../../src/util/Logger';
+import Product from '@requisite/model/lib/product/Product';
+import { ValidationResult } from '@requisite/utils/lib/validation/ValidationUtils';
+import Organization from '@requisite/model/lib/org/Organization';
+import Membership from '@requisite/model/lib/user/Membership';
+
+configure('ERROR');
+
+describe('GET /orgs/<orgId>/memberships/<orgMembershipId>', () => {
+    test('returns a 401 Unauthorized response when no auth header is present', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when an invalid auth header is present', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer invalid')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for an unknown user', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|unknown')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for a revoked user', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|revoked')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 403 Not Authorized when a valid auth header is present but not for an org owner or member', async () => {
+        return request(getApp())
+            .get('/orgs/1/memberships/0')
+            .set('Authorization', 'Bearer valid|local|org0MemberProduct0Owner')
+            .expect(403, 'Not Authorized');
+    });
+    test('returns a 400 Bad Request response when an invalid index', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/abc')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 404 Not Found response when an unknown index', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/123')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(404, 'Not Found');
+    });
+    test('returns a 200 with data when a valid auth header is present for a sys admin', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(200)
+            .then((res) => {
+                const result = res.body as Membership<Organization>;
+                expect(result).toEqual(expect.objectContaining({
+                    id: 0,
+                    entity: expect.objectContaining({
+                        id: 0
+                    }),
+                    user: expect.objectContaining({
+                        userName: 'org0Owner'
+                    })
+                }));
+            });
+    });
+    test('returns a 200 with data when a valid auth header is present for a org owner', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .expect(200)
+            .then((res) => {
+                const result = res.body as Membership<Organization>;
+                expect(result).toEqual(expect.objectContaining({
+                    id: 0,
+                    entity: expect.objectContaining({
+                        id: 0
+                    }),
+                    user: expect.objectContaining({
+                        userName: 'org0Owner'
+                    })
+                }));
+            });
+    });
+    test('returns a 200 with data when a valid auth header is present for a org member', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|org0MemberProduct0Owner')
+            .expect(200)
+            .then((res) => {
+                const result = res.body as Membership<Organization>;
+                expect(result).toEqual(expect.objectContaining({
+                    id: 0,
+                    entity: expect.objectContaining({
+                        id: 0
+                    }),
+                    user: expect.objectContaining({
+                        userName: 'org0Owner'
+                    })
+                }));
+            });
+    });
+});

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.put.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.put.test.ts
@@ -1,0 +1,195 @@
+import '../supertest.mock.sqlz';
+import '../supertest.mock.jsonwebtoken';
+import request from 'supertest';
+import { getApp } from '../../src/app';
+import { configure } from '../../src/util/Logger';
+import { ValidationResult } from '@requisite/utils/lib/validation/ValidationUtils';
+import OrgMembershipsDataModel from '../../src/services/sqlz/data-models/OrgMembershipsDataModel';
+import { getSequelize } from '../../src/services/sqlz/SqlzUtils';
+import Organization from '@requisite/model/lib/org/Organization';
+import Membership, { OrganizationRole } from '@requisite/model/lib/user/Membership';
+
+configure('ERROR');
+
+async function getMockedOrgMemberships(
+    orgId: number
+): Promise<Membership<Organization>[]> {
+    OrgMembershipsDataModel.initialize(await getSequelize());
+    return (await OrgMembershipsDataModel.findAll({
+        where: { orgId }
+    })).map(
+        m => OrgMembershipsDataModel.toOrgMembership(m)
+    );
+}
+
+describe('PUT /orgs/<orgId>/memberships/<orgMembershipId>', () => {
+    test('returns a 401 Unauthorized response when no auth header is present', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when an invalid auth header is present', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer invalid')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for an unknown user', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|unknown')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for a revoked user', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|revoked')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 403 Not Authorized when a valid auth header is present but not for an org owner', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|org0MemberProduct0Owner')
+            .expect(403, 'Not Authorized');
+    });
+    test('returns a 400 Bad Request response when an invalid index', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/abc')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 404 Not Found response when an unknown index', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/123')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(404, 'Not Found');
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but no body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(3);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only user in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ user: { id: 0 }})
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only an entity in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ entity: { id: 0 } })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only a role in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ role: 'OWNER' })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only user and entity in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ user: { id: 1 }, entity: { id: 0 } })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only user and role in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ user: { id: 1 }, role: 'OWNER' })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 400 Bad Request response for a valid auth header for the request resource but only an entity and role in the body', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ entity: { id: 0 }, role: 'OWNER' })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 200 with data when a valid auth header and data is present for a sys admin', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/1')
+            .send({ user: { id: 0 }, entity: { id: 0 }, role: OrganizationRole.OWNER })
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(200)
+            .then((res) => {
+                const result = res.body as Membership<Organization>;
+                expect(result).toEqual(expect.objectContaining({
+                    id: 1,
+                    entity: expect.objectContaining({
+                        id: 0
+                    }),
+                    user: expect.objectContaining({
+                        id: 0
+                    }),
+                    role: 'OWNER'
+                }));
+            });
+    });
+    test('returns a 200 with data when a valid auth header and data is present for an org owner', async () => {
+        return request(getApp())
+            .put('/orgs/0/memberships/0')
+            .send({ user: { id: 0 }, entity: { id: 0 }, role: OrganizationRole.OWNER })
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .expect(200)
+            .then((res) => {
+                const result = res.body as Membership<Organization>;
+                expect(result).toEqual(expect.objectContaining({
+                    id: 0,
+                    entity: expect.objectContaining({
+                        id: 0
+                    }),
+                    user: expect.objectContaining({
+                        id: 0
+                    }),
+                    role: 'OWNER'
+                }));
+            });
+    });
+});

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.list.get.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.list.get.test.ts
@@ -1,0 +1,122 @@
+import '../supertest.mock.sqlz';
+import '../supertest.mock.jsonwebtoken';
+import request from 'supertest';
+import { getApp } from '../../src/app';
+import { configure } from '../../src/util/Logger';
+import Organization from '@requisite/model/lib/org/Organization';
+import Membership from '@requisite/model/lib/user/Membership';
+
+configure('ERROR');
+
+describe('GET /orgs/<orgId>/memberships', () => {
+    test('returns a 401 Unauthorized response when no auth header is present', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when an invalid auth header is present', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer invalid')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for an unknown user', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|unknown')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for a revoked user', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|revoked')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 403 Not Authorized response when a valid auth header is present for a user of a different org', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org1MemberProduct2Owner')
+            .expect(403, 'Not Authorized');
+    });
+    test('returns a 200 with membership data if a valid auth header is present for a system admin', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .expect(200)
+            .then((res) => {
+                const results = res.body as Membership<Organization>[];
+                expect(
+                    results.every(membership => membership.entity.id === 0)
+                ).toBeTruthy();
+                expect(results).toEqual(expect.arrayContaining([
+                    expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0Owner'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0MemberProduct0Owner'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0and1Member'
+                        })
+                    })
+                ]));
+            });
+    });
+    test('returns a 200 with membership data if a valid auth header is present for an owner of an org', async () => {
+        return request(getApp())
+            .get('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .expect(200)
+            .then((res) => {
+                const results = res.body as Membership<Organization>[];
+                expect(
+                    results.every(membership => membership.entity.id === 0)
+                ).toBeTruthy();
+                expect(results).toEqual(expect.arrayContaining([
+                    expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0Owner'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0MemberProduct0Owner'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0and1Member'
+                        })
+                    })
+                ]));
+            });
+    });
+    test('returns a 200 with membership data if a valid auth header is present for a member of an org', async () => {
+        return request(getApp())
+            .get('/orgs/1/memberships')
+            .set('Authorization', 'Bearer valid|local|org1MemberProduct2Stakeholder')
+            .expect(200)
+            .then((res) => {
+                const results = res.body as Membership<Organization>[];
+                expect(
+                    results.every(membership => membership.entity.id === 1)
+                ).toBeTruthy();
+                expect(results).toEqual(expect.arrayContaining([
+                    expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org1MemberProduct2Owner'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org1MemberProduct2Stakeholder'
+                        })
+                    }), expect.objectContaining({
+                        user: expect.objectContaining({
+                            userName: 'org0and1Member'
+                        })
+                    })
+                ]));
+            });
+    });
+});

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.list.post.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.list.post.test.ts
@@ -1,0 +1,195 @@
+import '../supertest.mock.sqlz';
+import '../supertest.mock.jsonwebtoken';
+import request from 'supertest';
+import { getApp } from '../../src/app';
+import { configure } from '../../src/util/Logger';
+import Organization from '@requisite/model/lib/org/Organization';
+import { ValidationResult } from '@requisite/utils/lib/validation/ValidationUtils';
+import { getSequelize } from '../../src/services/sqlz/SqlzUtils';
+import Product from '@requisite/model/lib/product/Product';
+import OrganizationsDataModel from '../../src/services/sqlz/data-models/OrganizationsDataModel';
+import Membership from '@requisite/model/lib/user/Membership';
+import OrgMembershipsDataModel from '../../src/services/sqlz/data-models/OrgMembershipsDataModel';
+
+async function getMockedOrgMemberships(): Promise<Membership<Organization>[]> {
+    OrganizationsDataModel.initialize(await getSequelize());
+    return (await OrgMembershipsDataModel.findAll()).map(
+        o => OrgMembershipsDataModel.toOrgMembership(o)
+    );
+}
+
+configure('ERROR');
+
+describe('POST /org/<orgId>/memberships', () => {
+
+    test('returns a 401 Unauthorized response when no auth header is present', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when an invalid auth header is present', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer invalid')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for an unknown user', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|unknown')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 401 Unauthorized response when a valid auth header is present for a revoked user', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|revoked')
+            .expect(401, 'Unauthorized');
+    });
+    test('returns a 403 Forbidden response when an auth header for a non org owner', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0MemberProduct0Owner')
+            .expect(403, 'Not Authorized');
+    });
+    test('returns a 400 Bad Request response with 3 error when the request body is empty for an org owner', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({})
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(3);
+            });
+    });
+    test('returns a 400 Bad Request response with 2 errors when the request body has only a user for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({ user: { id: 0 } })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response with 2 errors when the request body has only an entity for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({ entity: { id: 0 } })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response with 2 errors when the request body has only a role for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({ role: 'OWNER' })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(2);
+            });
+    });
+    test('returns a 400 Bad Request response with 1 error when the request body has only a user and a role for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({
+                user: { id: 0 },
+                role: 'OWNER'
+            })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 400 Bad Request response with 1 error when the request body has only a entity and a role for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({
+                entity: { id: 0 },
+                role: 'OWNER'
+            })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 400 Bad Request response with 1 error when the request body has only a user and an entity for an org membership', async () => {
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({
+                user: { id: 0 },
+                entity: { id: 0 }
+            })
+            .expect(400)
+            .then((res) => {
+                const results = res.body as ValidationResult;
+                expect(results.valid).toBe(false);
+                expect(Object.keys(results.errors || {}).length).toBe(1);
+            });
+    });
+    test('returns a 200 with the new record when the request body is valid for a system admin', async () => {
+        const orgMemberships = await getMockedOrgMemberships();
+        const orgMembershipsCount = orgMemberships.length;
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|sysadmin')
+            .send({
+                user: { id: 0 },
+                entity: { id: 0 },
+                role: 'OWNER'
+            })
+            .expect(200)
+            .then(async (res) => {
+                const result = res.body as Product;
+                expect(result).toEqual({
+                    id: expect.any(Number),
+                    user: expect.objectContaining({ id: 0 }),
+                    entity: expect.objectContaining({ id: 0 }),
+                    role: 'OWNER'
+                });
+                const updatedOrgMemberships = await getMockedOrgMemberships();
+                expect(updatedOrgMemberships.length).toBe(orgMembershipsCount+1);
+            });
+    });
+    test('returns a 200 with the new record when the request body is valid for an org owner', async () => {
+        const orgMemberships = await getMockedOrgMemberships();
+        const orgMembershipsCount = orgMemberships.length;
+        return request(getApp())
+            .post('/orgs/0/memberships')
+            .set('Authorization', 'Bearer valid|local|org0Owner')
+            .send({
+                user: { id: 0 },
+                entity: { id: 0 },
+                role: 'OWNER'
+            })
+            .expect(200)
+            .then(async (res) => {
+                const result = res.body as Product;
+                expect(result).toEqual({
+                    id: expect.any(Number),
+                    user: expect.objectContaining({ id: 0 }),
+                    entity: expect.objectContaining({ id: 0 }),
+                    role: 'OWNER'
+                });
+                const updatedOrgMemberships = await getMockedOrgMemberships();
+                expect(updatedOrgMemberships.length).toBe(orgMembershipsCount+1);
+            });
+    });
+});

--- a/requisite-api/tests/supertest.mock.sqlz.ts
+++ b/requisite-api/tests/supertest.mock.sqlz.ts
@@ -342,6 +342,7 @@ jest.mock('sequelize', () => {
                 ...membership,
                 id: mockOrgMemberships.length,
                 userId: user.id,
+                orgId: membership.entity.id,
                 user
             } as unknown as Membership<Organization>);
         });
@@ -355,6 +356,7 @@ jest.mock('sequelize', () => {
                 ...membership,
                 id: mockProductMemberships.length,
                 userId: user.id,
+                productId: membership.entity.id,
                 user
             } as unknown as Membership<Product>);
         });

--- a/requisite-model/lib/Entity.ts
+++ b/requisite-model/lib/Entity.ts
@@ -6,3 +6,15 @@ export default interface Entity {
     updatedAt: Date;
     updatedBy: User;
 }
+
+export const EntityIdentifierSchema: unknown = {
+    title: 'Entity Identifier',
+    description: 'Properties that identify an entity',
+    type: 'object',
+    properties: {
+        id: {
+            type: 'number'
+        }
+    },
+    required: ['id']
+};

--- a/requisite-model/lib/org/Organization.ts
+++ b/requisite-model/lib/org/Organization.ts
@@ -11,7 +11,7 @@ export default interface Organization extends Entity {
 
 export const OrganizationSchema: unknown = {
     title: 'Organization',
-    description: 'Request object to login a user',
+    description: 'Entity representing an organization',
     type: 'object',
     properties: {
         id: {

--- a/requisite-model/lib/user/Membership.ts
+++ b/requisite-model/lib/user/Membership.ts
@@ -1,5 +1,5 @@
 import User from './User';
-import Entity from '../Entity';
+import Entity, { EntityIdentifierSchema } from '../Entity';
 
 export default interface Membership<T> extends Entity {
     user: User;
@@ -21,3 +21,21 @@ export enum ProductRole {
     STAKEHOLDER = 'STAKEHOLDER',
     CONTRIBUTOR = 'CONTRIBUTOR'
 }
+
+export const MembershipSchema: unknown = {
+    title: 'Membership',
+    description: 'Entity representing a membership',
+    type: 'object',
+    properties: {
+        id: {
+            type: 'number'
+        },
+        user: EntityIdentifierSchema,
+        entity: EntityIdentifierSchema,
+        role: {
+            type: 'string',
+            isNotBlank: true
+        }
+    },
+    required: ['user', 'entity', 'role']
+};


### PR DESCRIPTION
Description: completion and testing of organization membership apis

- added tests for all 5 apis
- added a new entity handler for injecting an entity record on a request
- added schemas for validating memberships
- fixed bugs found in org membership apis
- cleaned up some typescript type conversions that were no longer needed
- added jest coverage thresholds back to quality checks. still not back up to thresholds from several months ago when I foolishly dumped a bunch of untested code into the repo, but getting a lot closer