### PR TITLE
Added logic so that only roles can be updated on organization permiss…

### DIFF
--- a/README_IDEAS.md
+++ b/README_IDEAS.md
@@ -86,3 +86,7 @@ These are ideas that I have or technologies that I come across that I think are 
 - look at dflex for drag'n'drop
 - look at integrating memlab for memory leak testing (https://engineering.fb.com/2022/09/12/open-source/memlab/?utm_source=tldrnewsletter)
 - look at coroot for microservice monitoring https://github.com/coroot/coroot?utm_source=tldrnewsletter
+- look at modern-errors for custom error classes https://www.npmjs.com/package/modern-errors
+- look at vale.sh - looks like linting for markdown files
+- Look at BlockSuite for creating content editors - https://github.com/toeverything/blocksuite
+- look at [inkline](https://www.inkline.io/) for a design/component library option

--- a/requisite-api/src/common/ResourceErrorHandler.ts
+++ b/requisite-api/src/common/ResourceErrorHandler.ts
@@ -17,15 +17,15 @@ const getErrorHandler = () => {
             if (resourceError instanceof SystemError) {
                 logger.error(
                     'A system error was encountered',
-                    (resourceError as SystemError).error
+                    resourceError.error
                 );
             }
             res.status(resourceError.statusCode);
             if (resourceError instanceof BadRequestError
-                && (resourceError as BadRequestError).validationResult) {
-                res.json((resourceError as BadRequestError).validationResult);
+                && resourceError.validationResult) {
+                res.json(resourceError.validationResult);
             } else if (resourceError instanceof ConflictError
-                && (resourceError as ConflictError).conflictReason) {
+                && resourceError.conflictReason) {
                 res.json({ ...resourceError });
             } else {
                 res.send(resourceError.message);

--- a/requisite-api/src/resources/organization-memberships/OrgMembershipsUpdateResource.ts
+++ b/requisite-api/src/resources/organization-memberships/OrgMembershipsUpdateResource.ts
@@ -5,7 +5,7 @@ import ServiceProvider from '../../services/ServiceProvider';
 import Organization from '@requisite/model/lib/org/Organization';
 import { assertExists } from '@requisite/utils/lib/validation/AssertionUtils';
 import Membership from '@requisite/model/lib/user/Membership';
-import { NotFoundError } from '../../util/ApiErrors';
+import { NotFoundError, ConflictError } from '../../util/ApiErrors';
 
 const logger = getLogger('resources/organizations/OrgMembershipsUpdateResource');
 
@@ -19,12 +19,40 @@ export default (req: ResourceRequest, res: Response, next: NextFunction): void =
             const organizationsService = ServiceProvider.getOrganizationsService();
             const membership = await organizationsService.getMembership(id);
             if (membership && membership.entity.id === req.organization.id) {
+
                 const modMembership: Membership<Organization>
                     = req.body as Membership<Organization>;
-                modMembership.id = id;
-                modMembership.entity = req.organization;
-                await organizationsService.updateMembership(modMembership);
-                res.status(200).send(modMembership);
+
+                const membershipIdConflict =
+                    modMembership.id !== null
+                    && modMembership.id !== undefined
+                    && modMembership.id !== membership.id;
+
+                const entityIdConfict =
+                    modMembership.entity
+                    && modMembership.entity.id !== null
+                    && modMembership.entity.id !== undefined
+                    && modMembership.entity.id !== membership.entity.id;
+
+                const userIdConfict =
+                    modMembership.user
+                    && modMembership.user.id !== null
+                    && modMembership.user.id !== undefined
+                    && modMembership.user.id !== membership.user.id;
+
+                if (membershipIdConflict) {
+                    next(new ConflictError('The membership identifier in the body does not match the uri.'));
+                } else if (entityIdConfict) {
+                    next(new ConflictError('The entity identifier in the body does not match the entity on the membership from the uri.  Entities cannot be changed on a membership'));
+                } else if (userIdConfict) {
+                    next(new ConflictError('The user identifier in the body does not match the user on the membership from the uri.  Users cannot be changed on a membership'));
+                } else {
+                    modMembership.id = id;
+                    modMembership.entity = req.organization;
+                    modMembership.user = membership.user;
+                    await organizationsService.updateMembership(modMembership);
+                    res.status(200).send(modMembership);
+                }
             } else {
                 next(new NotFoundError());
             }

--- a/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.put.test.ts
+++ b/requisite-api/tests/org-memberships/supertest.app.org-memberships.item.put.test.ts
@@ -177,8 +177,48 @@ describe('PUT /orgs/<orgId>/memberships/<orgMembershipId>', () => {
                 expect(Object.keys(results.errors || {}).length).toBe(1);
             });
     });
-    // TODO Tests for changing a user or entity should fail (400?).
-    // Should only be able to update the role
+    test('returns a 409 Conflict response for a valid auth header for the request resource but a different membership id in the body', async () => {
+        const org = await getMockedOrg();
+        const membership = await getMockedOrgMembership({ entity: org });
+        const sysAdmin = await getMockedUserForSystemAdmin();
+        return request(getApp())
+            .put(`/orgs/${org.id}/memberships/${membership.id}`)
+            .send({
+                id: membership.id + 1,
+                user: membership.user,
+                entity: membership.entity,
+                role: OrganizationRole.OWNER
+            })            .set('Authorization', `Bearer valid|local|${sysAdmin.userName}`)
+            .expect(409);
+    });
+    test('returns a 409 Conflict response for a valid auth header for the request resource but a different entity id in the body', async () => {
+        const org = await getMockedOrg();
+        const membership = await getMockedOrgMembership({ entity: org });
+        const sysAdmin = await getMockedUserForSystemAdmin();
+        return request(getApp())
+            .put(`/orgs/${org.id}/memberships/${membership.id}`)
+            .send({
+                id: membership.id,
+                user: membership.user,
+                entity: { id: membership.entity.id + 1 },
+                role: OrganizationRole.OWNER
+            })            .set('Authorization', `Bearer valid|local|${sysAdmin.userName}`)
+            .expect(409);
+    });
+    test('returns a 409 Conflict response for a valid auth header for the request resource but a different user id in the body', async () => {
+        const org = await getMockedOrg();
+        const membership = await getMockedOrgMembership({ entity: org });
+        const sysAdmin = await getMockedUserForSystemAdmin();
+        return request(getApp())
+            .put(`/orgs/${org.id}/memberships/${membership.id}`)
+            .send({
+                id: membership.id,
+                user: { id: membership.user.id + 1 },
+                entity: membership.entity,
+                role: OrganizationRole.OWNER
+            })            .set('Authorization', `Bearer valid|local|${sysAdmin.userName}`)
+            .expect(409);
+    });
     test('returns a 200 with data when a valid auth header and data is present for a sys admin', async () => {
         const org = await getMockedOrg();
         const membership = await getMockedOrgMembership({ entity: org });

--- a/requisite-utils/lib/validation/ValidationUtils.ts
+++ b/requisite-utils/lib/validation/ValidationUtils.ts
@@ -5,6 +5,7 @@ import { isNotBlank } from '../lang/StringUtils';
 export interface ValidationResult {
     valid: boolean;
     errors?: ValidationErrors;
+    message?: string;
 }
 
 export interface ValidationErrors {


### PR DESCRIPTION
Description: Added logic so that only roles can be updated on organization permissions.  Any conflicting data will return a 409 conflict error.
- Added logic mentioned above to the `OrgMembershipsUpdateResource`
- Fixed some unnecessary typescript casting in the `ResourceErrorHandler`
- Added tests for the new error use cases
- Added some more notes to the IDEAS file